### PR TITLE
去掉恢复下载进度时不必要的请求

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-*pyc
+*.pyc
 *.mp4
+*.DS_store

--- a/crawler.py
+++ b/crawler.py
@@ -8,9 +8,6 @@ import copy
 
 
 def scrape(ci, folderPath, downloadList, urls):
-    response = requests.get(urls, headers=headers, timeout=10)
-    content_ts = response.content
-
     os.path.split(urls)
     fileName = urls.split('/')[-1][0:-3]
     saveName = os.path.join(folderPath, fileName + ".mp4")
@@ -19,11 +16,12 @@ def scrape(ci, folderPath, downloadList, urls):
         print('當前目標: {0} 已下載, 故跳過...剩餘 {1} 個'.format(
             urls.split('/')[-1], len(downloadList)))
     else:
+        response = requests.get(urls, headers=headers, timeout=10)
+        content_ts = response.content
+        if ci:
+            content_ts = ci.decrypt(content_ts)  # 解碼
         with open(saveName, 'ab') as f:
-            if ci:
-                f.write(ci.decrypt(content_ts))  # 解碼
-            else:
-                f.write(content_ts)
+            f.write(content_ts)
             # 輸出進度
             print('當前下載: {0} , 剩餘 {1} 個'.format(
                 urls.split('/')[-1], len(downloadList)))


### PR DESCRIPTION
Hello 老哥，我刚才注意到从断点恢复下载进度时候依然对视频内容进行请求了，所以和原先比没有节约流量和时间😂
于是修改了这一行为（在`crawler.py`），遇到已经下载的只要从本地判断文件是不是存在就可以了～

之后，我在想方便的话是否把网址放在命令行参数里，这样如果直接从命令历史中就可以看到下载记录了，如果下载中断也方便回复。简单实现来说可以从`sys.argv[]`读取输入的url，当然比较合适的方案是写一个argumentparser实例，这样还可以指定其他参数比如是否通过ffmpeg转码，是否保留原文件，下载路径等等……

不过这些就属于锦上添花所以应该由作者本人决定哈哈，所以如果你觉得有需要的话可以做一下😄