### PR TITLE
"chrome_options has been removed on Selenium 4.10.0, so the update is options=options."

### DIFF
--- a/download.py
+++ b/download.py
@@ -43,7 +43,7 @@ def download(url):
   options.add_argument('--disable-extensions')
   options.add_argument('--headless')
   options.add_argument("user-agent=Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36")
-  dr = webdriver.Chrome(chrome_options=options)
+  dr = webdriver.Chrome(options=options)
   dr.get(url)
   result = re.search("https://.+m3u8", dr.page_source)
   print(f'result: {result}')


### PR DESCRIPTION
fix 
```
dr = webdriver.Chrome(chrome_options=options)
TypeError: init() got an unexpected keyword argument 'chrome_options'
```

"chrome_options has been removed on Selenium 4.10.0, so the update is options=options."

new code

```
dr = webdriver.Chrome(options=options)
TypeError: init() got an unexpected keyword argument 'chrome_options'
```